### PR TITLE
Adjust build.gradle for 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT' apply false
-    id 'net.neoforged.moddev' version '2.0.107' apply false
+    id 'fabric-loom' version '1.13-SNAPSHOT' apply false
+    id 'net.neoforged.moddev' version '2.0.123' apply false
 }

--- a/common/src/main/java/com/diontryban/ash_api/client/input/KeyMappingRegistry.java
+++ b/common/src/main/java/com/diontryban/ash_api/client/input/KeyMappingRegistry.java
@@ -21,7 +21,7 @@ package com.diontryban.ash_api.client.input;
 import com.diontryban.ash_api.ServiceUtil;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,7 +33,7 @@ public abstract class KeyMappingRegistry {
     /**
      * Registers a {@link KeyMapping}.
      *
-     * @param modId your mod's mod id
+     * @param modId      your mod's mod id
      * @param keyMapping the key mapping
      * @return the key mapping
      */
@@ -46,39 +46,42 @@ public abstract class KeyMappingRegistry {
      * Helper method of {@link KeyMappingRegistry#register(String, KeyMapping)}.
      * It constructs a {@link KeyMapping} for you with constructor arguments.
      *
-     * @param resLoc your mod's mod id and the key mapping's unique name
+     * @param resLoc    your mod's mod id and the key mapping's unique name
      * @param inputType type of input
-     * @param key e.g., GLFW.GLFW_KEY_R
-     * @param category key category
+     * @param key       e.g., GLFW.GLFW_KEY_R
+     * @param category  key category
      * @return the key mapping
      */
     @ApiStatus.AvailableSince("21.0.0-beta")
     public static @NotNull KeyMapping register(
-            @NotNull ResourceLocation resLoc,
+            @NotNull Identifier resLoc,
             @NotNull InputConstants.Type inputType,
             int key,
             @NotNull String category
     ) {
+        //TODO throws exception if category already exists; add catch
+        var cat = KeyMapping.Category.register(Identifier.fromNamespaceAndPath(resLoc.getNamespace(), category));
+
         return register(resLoc.getNamespace(), new KeyMapping(
                 String.format("key.%s.%s", resLoc.getNamespace(), resLoc.getPath()),
                 inputType,
                 key,
-                String.format("key.categories.%s", category)
+                cat
         ));
     }
 
     /**
-     * Helper method of {@link KeyMappingRegistry#register(ResourceLocation, InputConstants.Type, int, String)}.
+     * Helper method of {@link KeyMappingRegistry#register(Identifier, InputConstants.Type, int, String)}.
      * It passes the default inputType of {@code InputConstants.Type.KEYSYM}.
      *
-     * @param resLoc your mod's id and the key mapping's unique name
-     * @param key e.g., GLFW.GLFW_KEY_R
+     * @param resLoc   your mod's id and the key mapping's unique name
+     * @param key      e.g., GLFW.GLFW_KEY_R
      * @param category key category
      * @return the key mapping
      */
     @ApiStatus.AvailableSince("21.0.0-beta")
     public static @NotNull KeyMapping register(
-            @NotNull ResourceLocation resLoc,
+            @NotNull Identifier resLoc,
             int key,
             @NotNull String category
     ) {

--- a/fabric/src/main/java/com/diontryban/ash_api/resources/ResourceLoaderFabric.java
+++ b/fabric/src/main/java/com/diontryban/ash_api/resources/ResourceLoaderFabric.java
@@ -21,10 +21,9 @@ package com.diontryban.ash_api.resources;
 
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
-import net.minecraft.server.packs.resources.ResourceManager;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,22 +55,22 @@ public final class ResourceLoaderFabric extends ResourceLoader {
 
         resourceManagerHelper.registerReloadListener(new IdentifiableResourceReloadListener() {
                 @Override
-                public ResourceLocation getFabricId() {
-                    return ResourceLocation.parse(reloadListener.getName());
-                }
+                    public Identifier getFabricId() {
+                        return Identifier.parse(reloadListener.getName());
+                    }
 
                 @Override
-                public @NotNull CompletableFuture<Void> reload(
-                        PreparationBarrier preparationBarrier,
-                        ResourceManager resourceManager,
-                        Executor backgroundExecutor,
-                        Executor gameExecutor
+                public CompletableFuture<Void> reload(
+                        SharedState sharedState,
+                        Executor exectutor,
+                        PreparationBarrier barrier,
+                        Executor applyExectutor
                 ) {
                     return reloadListener.reload(
-                            preparationBarrier,
-                            resourceManager,
-                            backgroundExecutor,
-                            gameExecutor
+                            sharedState,
+                            exectutor,
+                            barrier,
+                            applyExectutor
                     );
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,26 +10,26 @@ java_version=21
 mod_id=ash_api
 mod_name=Ash API
 mod_author=Trikzon
-version=21.6.0-beta
+version=21.11.0-beta
 license=LGPL-3.0-or-later
 credits=
 description=An API that provides an abstraction layer over Fabric and NeoForge APIs.
 
 # Common
-minecraft_version=1.21.6
-minecraft_version_range=[1.21.6, 1.22)
-neoform_version=1.21.6-20250617.151856
-parchment_minecraft_version=1.21.6
-parchment_version=2025.06.29
+minecraft_version=1.21.11
+minecraft_version_range=[1.21.11, 1.22)
+neoform_version=1.21.11-20251209.172050
+parchment_minecraft_version=1.21.10
+parchment_version=2025.10.12
 ash_version=
 
 # Fabric
-fabric_version=0.128.2+1.21.6
-fabric_loader_version=0.17.2
-modmenu_version=15.0.0-beta.3
+fabric_version=0.140.2+1.21.11
+fabric_loader_version=0.18.4
+modmenu_version=17.0.0-beta.2
 
 # NeoForge
-neoforge_version=21.6.20-beta
+neoforge_version=21.11.17-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/neoforge/src/main/java/com/diontryban/ash_api/modloader/ModLoaderNeoForge.java
+++ b/neoforge/src/main/java/com/diontryban/ash_api/modloader/ModLoaderNeoForge.java
@@ -41,7 +41,7 @@ public final class ModLoaderNeoForge extends ModLoader {
 
     @Override
     protected boolean isDevelopmentEnvironmentImpl() {
-        return !FMLLoader.isProduction();
+        return !FMLLoader.getCurrent().isProduction();
     }
 
     @Override

--- a/neoforge/src/main/java/com/diontryban/ash_api/resources/ResourceLoaderNeoForge.java
+++ b/neoforge/src/main/java/com/diontryban/ash_api/resources/ResourceLoaderNeoForge.java
@@ -20,7 +20,7 @@
 package com.diontryban.ash_api.resources;
 
 import com.diontryban.ash_api.AshApi;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.neoforged.fml.ModList;
@@ -58,7 +58,7 @@ public final class ResourceLoaderNeoForge extends ResourceLoader {
     @Override
     public void registerReloadListener(@NotNull PreparableReloadListener reloadListener) {
         if (type == PackType.CLIENT_RESOURCES) {
-            var modId = ResourceLocation.parse(reloadListener.getName()).getNamespace();
+            var modId = Identifier.parse(reloadListener.getName()).getNamespace();
 
             if (!CLIENT_RELOAD_LISTENERS.containsKey(modId)) {
                 CLIENT_RELOAD_LISTENERS.put(modId, new ConcurrentLinkedQueue<>());
@@ -86,13 +86,13 @@ public final class ResourceLoaderNeoForge extends ResourceLoader {
 
     private void onAddClientReloadListener(AddClientReloadListenersEvent event, String modId) {
         for (PreparableReloadListener reloadListener : CLIENT_RELOAD_LISTENERS.get(modId)) {
-            event.addListener(ResourceLocation.parse(reloadListener.getName()), reloadListener);
+            event.addListener(Identifier.parse(reloadListener.getName()), reloadListener);
         }
     }
 
     private void onAddServerReloadListener(AddServerReloadListenersEvent event) {
         for (PreparableReloadListener reloadListener : SERVER_RELOAD_LISTENERS) {
-            event.addListener(ResourceLocation.parse(reloadListener.getName()), reloadListener);
+            event.addListener(Identifier.parse(reloadListener.getName()), reloadListener);
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,28 @@ pluginManagement {
                 includeGroup('fabric-loom')
             }
         }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = 'Sponge'
+                    url = uri('https://repo.spongepowered.org/repository/maven-public')
+                }
+            }
+            filter {
+                includeGroupAndSubgroups("org.spongepowered")
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = 'Forge'
+                    url = uri('https://maven.minecraftforge.net')
+                }
+            }
+            filter {
+                includeGroupAndSubgroups('net.minecraftforge')
+            }
+        }
     }
 }
 
@@ -23,6 +45,6 @@ plugins {
 }
 
 rootProject.name = 'ash-api'
-include('common')
-include('fabric')
-include('neoforge')
+include("common")
+include("fabric")
+include("neoforge")


### PR DESCRIPTION
adjust gradle.properties for 1.21.11
adjust settings.gradle for 1.21.11

loosely fix KeyMappingRegistry: the category getter/registrar throws an error if it already exists.  
Fix IdentifiableResourceReloadListener implementation with correct override in ResourceLoaderFabric.

update 'ResLoc' to new mapping name : Identifier